### PR TITLE
Add support for FlightRadar24

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,13 @@ Note: Currently you need to BYO grafana/prometheus, I will be adding internal de
 | dump1090exporter.nodeport.port | int | `30070` |  |
 | feeder_id | string | `nil` |  |
 | fr24feed_key | string | `nil` |  |
+| fr24feed.beasthost | string | `http-nodeport.flightaware.svc` |  |
+| fr24feed.beastport | string | `30005` |  |
 | fr24feed.enabled | bool | `false` |  |
 | fr24feed.image.repository | string | `mikenye/fr24feed` |  | 
 | fr24feed.image.pullPolicy | string | `IfNotPresent` |  |
 | fr24feed.image.tag | string | `latest` |  |
+| fr24feed.mlat | string | `yes` |  |
 | fr24feed.nodeport.enable | bool | `false` |  |
 | fr24feed.nodeport.port | int | `30072` |  |
 | fullnameOverride | string | `""` |  |

--- a/README.md
+++ b/README.md
@@ -11,19 +11,29 @@
 
 [Flightaware Build Instructions](https://flightaware.com/adsb/piaware/build/)
 
-## Installation Instructions
+## Quick Start Installation Instructions
 ```bash
 # Add the kubeinflight helm chart repo
 helm repo add kubeinflight https://bgulla.github.io/kubeinflight
 helm repo update
 
+## Note: kubeinflight will only run on nodes that are labeled as having an SDR attached. Do the following:
+kubectl label node <node_with_usb_sdr> sdr=true
+
 # Install the helm chart
 helm install kubeinflight kubeinflight/kubeinflight  \
   -n flightaware \
   --create-namespace
+```
 
-## Note: kubeinflight will only run on nodes that are labeled as having an SDR attached. Do the following:
-kubectl label node <node_with_usb_sdr> sdr=true
+## Example Installation Instructions
+Installing full suite for reporting to FlightAware and FlightRadar24 with example ingress enabled
+```bash
+helm install kubeinflight kubeinflight/kubeinflight \
+  -n flightaware  --create-namespace --set replicaCount=1 \ 
+  --set lat="##.##########" --set long='-##.###########' \ 
+  --set ingress.enabled='true' --set 'ingress.hosts[0].host'='adbs.example.com' \
+  --set fr24feed.enabled='true' --set fr24feed_key='YOURFR24KEY'
 ```
 
 ## Prometheus/`dump1090exporter`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * [RTL2832U Software Defined Radio](https://www.amazon.com/RTL-SDR-Blog-RTL2832U-Software-Defined/dp/B0129EBDS2/ref=sr_1_3?keywords=rtl+sdr&qid=1636478210&qsid=133-2081778-9779013&sr=8-3&sres=B0129EBDS2%2CB01GDN1T4S%2CB008S7AVTC%2CB07WGWZS1D%2CB01HA642SW%2CB01B4L48QU%2CB06Y1GN5RP%2CB06Y1FDDBF%2CB079C4S2BT%2CB0132MB8LM%2CB07W6VFWGS%2CB0132N1DM0%2CB06Y1D7P48%2CB073JZ8CC2%2CB07W3XQKXV%2CB009U7WZCA)
 * A Kubernetes Cluster (we like [k3s](https://k3s.io).)
 * *[Optional]* A [FlightAware](https://flightaware.com) account / API-Key
+* *[Optional]* A [FlightRadar24](https://flightradar24.com) account / sharing key
 * [Latitude and Longitude for your location](https://www.latlong.net/_)
 
 [Flightaware Build Instructions](https://flightaware.com/adsb/piaware/build/)
@@ -48,6 +49,13 @@ Note: Currently you need to BYO grafana/prometheus, I will be adding internal de
 | dump1090exporter.nodeport.enable | bool | `true` |  |
 | dump1090exporter.nodeport.port | int | `30070` |  |
 | feeder_id | string | `nil` |  |
+| fr24feed_key | string | `nil` |  |
+| fr24feed.enabled | bool | `false` |  |
+| fr24feed.image.repository | string | `mikenye/fr24feed` |  | 
+| fr24feed.image.pullPolicy | string | `IfNotPresent` |  |
+| fr24feed.image.tag | string | `latest` |  |
+| fr24feed.nodeport.enable | bool | `false` |  |
+| fr24feed.nodeport.port | int | `30072` |  |
 | fullnameOverride | string | `""` |  |
 | grafana.auth.anonymous.enabled | bool | `true` |  |
 | grafana.auth.basic.enabled | bool | `true` |  |

--- a/charts/kubeinflight/Chart.yaml
+++ b/charts/kubeinflight/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10-dev
+version: 0.1.11-dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.17.1
+appVersion: 1.17.2

--- a/charts/kubeinflight/templates/configmap.yaml
+++ b/charts/kubeinflight/templates/configmap.yaml
@@ -9,6 +9,15 @@ data:
   LONG: {{ .Values.long | quote }}
   FEEDER_ID: {{ .Values.feeder_id | default "none" | quote }}
   RECEIVER_TYPE: {{ .Values.receiver_type | quote }}
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: flightradar-env-file
+  namespace: flightaware
+data:
+  FR24KEY: {{ .Values.fr24feed_key | default "none" | quote }}
 
 ---
 

--- a/charts/kubeinflight/templates/deployment.yaml
+++ b/charts/kubeinflight/templates/deployment.yaml
@@ -68,6 +68,22 @@ spec:
           - name: RESOURCE_PATH
             value: "http://localhost:8080/data"
       {{ end }}
+      {{ if .Values.fr24feed.enabled }}
+      - image: {{ .Values.fr24feed.image.repository }}:{{ .Values.fr24feed.image.tag }}
+        imagePullPolicy: {{ default "Always" .Values.fr24feed.image.pullPolicy }}
+        name: fr24feed
+        envFrom:
+        - configMapRef:
+            name: flightradar-env-file
+            optional: false
+        env:
+          - name: MLAT
+            value: {{ default "yes" .Values.fr24feed.mlat | quote }}
+          - name: BEASTHOST
+            value: http-nodeport.{{ default "flightaware" .Values.namespace }}.svc
+          - name: BEASTPORT
+            value: {{ default "30005" .Values.fr24feed.beasthost | quote }}
+      {{ end }}
       {{ if .Values.grafana.enabled }}
       - image: {{ default "grafana/grafana" .Values.grafana.image.repository }}:{{ default "latest" .Values.grafana.image.tag }}
         imagePullPolicy: {{ default "Always" .Values.grafana.image.pullPolicy }}

--- a/charts/kubeinflight/templates/deployment.yaml
+++ b/charts/kubeinflight/templates/deployment.yaml
@@ -80,9 +80,9 @@ spec:
           - name: MLAT
             value: {{ default "yes" .Values.fr24feed.mlat | quote }}
           - name: BEASTHOST
-            value: http-nodeport.{{ default "flightaware" .Values.namespace }}.svc
+            value: {{ default "http-nodeport.flightaware.svc" .Values.fr24feed.beasthost | quote }}
           - name: BEASTPORT
-            value: {{ default "30005" .Values.fr24feed.beasthost | quote }}
+            value: {{ default "30005" .Values.fr24feed.beastport | quote }}
       {{ end }}
       {{ if .Values.grafana.enabled }}
       - image: {{ default "grafana/grafana" .Values.grafana.image.repository }}:{{ default "latest" .Values.grafana.image.tag }}

--- a/charts/kubeinflight/templates/service.yaml
+++ b/charts/kubeinflight/templates/service.yaml
@@ -12,6 +12,15 @@ spec:
     port: 8080
     protocol: TCP
     targetPort: 8080
+  {{ if .Values.fr24feed.enabled }}
+  - name: fr24feed
+    {{ if .Values.fr24feed.nodeport.enable }}
+    nodePort: {{ default 30072 .Values.fr24feed.nodeport.port  }}
+    {{ end }}
+    port: 30005
+    protocol: TCP
+    targetPort: 30005
+  {{ end }}
   {{ if .Values.dump1090exporter.enabled }}
   - name: prom-exporter
     {{ if .Values.dump1090exporter.nodeport.enable }}
@@ -30,6 +39,7 @@ spec:
     protocol: TCP
     targetPort: 3000
   {{ end }}
+
   selector:
     app: apps.deployment-flightaware-piaware
   sessionAffinity: None

--- a/charts/kubeinflight/values.yaml
+++ b/charts/kubeinflight/values.yaml
@@ -15,6 +15,7 @@ long: "-76.2757609"
 tz: "America/New_York"
 receiver_type: rtlsdr
 feeder_id: #blank #https://flightaware.com/adsb/piaware/build/
+fr24feed_key: #blank #https://www.flightradar24.com/account/data-sharing
 
 
 piaware:
@@ -37,6 +38,16 @@ dump1090exporter:
   nodeport:
     enabled: true
     port: 30070
+
+fr24feed:
+  enabled: false
+  image:
+    repository: mikenye/fr24feed
+    pullPolicy: IfNotPresent
+    tag: latest
+  nodeport:
+    enabled: true
+    port: 30072
 
 ## TODO
 grafana:


### PR DESCRIPTION
This PR adds support for FlightRadar24.

* fr24feed is disabled by default, as it requires a sharing key
* This PR adds chart values, container data, configmaps, deployment charts for fr24feed
* This PR also exposes port 30005 on piaware container so other containers in the pod can access the dump1090 feed
* I bumped both the chart version and app version, but those can be adjusted however you see fit

This is my first PR on a helm chart like this. Please review and let me know any changes you'd like to see.